### PR TITLE
Add agenttrace

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@
 - [sqshq/sampler](https://github.com/sqshq/sampler) - A tool for shell commands execution, visualization and alerting. Configured with a simple YAML file.
 - [facebookincubator/below](https://github.com/facebookincubator/below) - A time traveling resource monitor for modern Linux systems
 - [iovisor/bcc](https://github.com/iovisor/bcc) - BCC - Tools for BPF-based Linux IO analysis, networking, monitoring, and more
+- [luoyuctl/agenttrace](https://github.com/luoyuctl/agenttrace) - TUI observability for AI coding agents: trace cost, tokens, tool failures, latency, anomalies, health, and diffs.
 
 ## <a name="performance"></a>performance
 


### PR DESCRIPTION
## Summary
- Add luoyuctl/agenttrace to the monitoring section.

## Why
- agenttrace is a terminal UI for observing AI coding agent sessions, including cost, tokens, latency, tool failures, anomalies, health, and diffs.

## Checks
- README-only change; inspected rendered Markdown diff locally.